### PR TITLE
Feature/refactors game

### DIFF
--- a/godot/project.godot
+++ b/godot/project.godot
@@ -12,6 +12,7 @@ config_version=5
 
 config/name="NapoleonGames"
 run/main_scene="uid://cllpyrjg508jg"
+run/enable_alt_space_menu=true
 config/features=PackedStringArray("4.6", "Forward Plus")
 config/icon="res://icon.svg"
 
@@ -27,6 +28,8 @@ AudioManager="*uid://cfgeh4loe71nm"
 
 window/size/viewport_width=1920
 window/size/viewport_height=1080
+window/size/window_width_override=720
+window/size/window_height_override=405
 window/stretch/mode="canvas_items"
 
 [editor]

--- a/godot/scenes/ingame/ability_manager.gd
+++ b/godot/scenes/ingame/ability_manager.gd
@@ -24,8 +24,11 @@ func request(hab: HabilityRes, coords: Vector2i, tile: TileGame) -> bool:
 	if _pending_hab != null:
 		cancel()
 
-	var unit    := tile.get_unit()
-	var targets := GameManager.get_map().get_units_range(coords, hab.radius, hab.objective)
+	var tm := GameManager.get_turn_manager()
+	var map := tm.get_map()
+	if map == null:
+		return false
+	var targets := map.get_units_range(coords, hab.radius, hab.objective)
 	if targets.is_empty():
 		push_warning("No hay objetivos válidos para '%s'" % hab.name)
 		return false
@@ -49,7 +52,12 @@ func try_select_target(coords: Vector2i) -> bool:
 	if _phase != Phase.SELECTING_TARGET:
 		return false
 
-	var valid := GameManager.get_map().get_units_range(_caster_coords, _pending_hab.radius, _pending_hab.objective)
+	var tm := GameManager.get_turn_manager()
+	var map := tm.get_map()
+	if map == null:
+		cancel()
+		return false
+	var valid := map.get_units_range(_caster_coords, _pending_hab.radius, _pending_hab.objective)
 	if coords not in valid:
 		cancel()
 		return false

--- a/godot/scenes/ingame/game_scene.tscn
+++ b/godot/scenes/ingame/game_scene.tscn
@@ -5,6 +5,7 @@
 
 [node name="GameScene" type="Node" unique_id=1075307019]
 script = ExtResource("1_4n5kr")
+turns = null
 
 [node name="IngameMap" parent="." unique_id=594307947 instance=ExtResource("2_rqqua")]
 

--- a/godot/scenes/ingame/ingame_map.gd
+++ b/godot/scenes/ingame/ingame_map.gd
@@ -28,11 +28,15 @@ var _selected_tile:   TileGame     = null
 var _selected_coords: Vector2i     = Vector2i(-1, -1)
 
 func _ready() -> void:
-	map = GameManager.get_map()
+	await get_tree().process_frame
+	if turn_manager == null:
+		turn_manager = GameManager.get_turn_manager()
+	map = turn_manager.get_map()
 	if map == null:
 		push_error("GameScene: no tiene mapa — usando mapa de test")
 		map = TestMapGame.new().create_test_map()
-		GameManager.set_map(map)
+		if turn_manager:
+			turn_manager.set_map(map)
 	map_visualizer._setup_map(map)
 
 	_hab_manager = HabilityManager.new()
@@ -144,7 +148,7 @@ func _on_map_tile_hovered(coords: Vector2i) -> void:
 			map_visualizer.clear_deployment_preview()
 		return
 
-	var result: Dictionary = GameManager._gameMap.calculate_deployment(
+	var result: Dictionary = map.calculate_deployment(
 		turn_manager.get_current_user_number(),
 		_pending_deployment_group.n,
 		coords

--- a/godot/scenes/ingame/turn_manager.gd
+++ b/godot/scenes/ingame/turn_manager.gd
@@ -16,9 +16,9 @@ var turn_number: int = 0
 var is_deployment_phase: bool = false
 
 func advance_turn() -> void:
+	turn_number += 1
 	var user : UserGame = turn_order[turn_number % turn_order.size()]
 	print("Turno de ", user.get_user_res().username)
-	turn_number += 1
 	tick_turn.emit()
 	
 	

--- a/godot/scenes/ingame/turn_manager.gd
+++ b/godot/scenes/ingame/turn_manager.gd
@@ -14,6 +14,8 @@ signal tick_turn
 var turn_order: Array[UserGame] = []
 var turn_number: int = 0
 var is_deployment_phase: bool = false
+var game_config: GameConfig
+var map_game: MapGame
 
 func advance_turn() -> void:
 	turn_number += 1
@@ -39,6 +41,36 @@ func is_player1_turn() -> bool:
 
 func get_player_cards(player: UserGame) -> int:
 	return player.get_deployment_count()
+
+func get_map() -> MapGame:
+	return map_game
+
+func set_map(new_map: MapGame) -> void:
+	map_game = new_map
+
+func get_game_config() -> GameConfig:
+	return game_config
+
+func get_game_resources() -> GameResources:
+	return GameManager.game_res
+
+func get_app_state() -> GameManager.APP_STATE:
+	return GameManager.app_state
+
+func set_app_state(state: GameManager.APP_STATE) -> void:
+	GameManager.app_state = state
+
+func get_user_a() -> UserRes:
+	return game_config.user_a
+
+func get_user_b() -> UserRes:
+	return game_config.user_b
+
+func get_army_a() -> ArmyRes:
+	return game_config.army_a
+
+func get_army_b() -> ArmyRes:
+	return game_config.army_b
 	
 	
 func register_turn(turn: TurnAction) -> bool:
@@ -72,15 +104,21 @@ func _replay_hability(turn: TurnHability) -> bool:
 
 # Called when the node enters the scene tree for the first time.
 func _ready() -> void:
-	GameManager.turn_manager = self 
+	GameManager.register_turn_manager(self)
+	game_config = GameManager.get_game_config()
+	if map_game == null and game_config and game_config.map_res:
+		map_game = MapGame.new(game_config.map_res)
 	if turn_order.is_empty() :
-		turn_order = [UserGame.new(GameManager._user_a), UserGame.new(GameManager._user_b)]
+		if game_config == null:
+			push_error("[TurnManager] Falta GameConfig para inicializar turn_order")
+		else:
+			turn_order = [UserGame.new(get_user_a()), UserGame.new(get_user_b())]
 
 	if turn_order.size() >= 2:
 		if turn_order[0].deployment_data.is_empty():
-			turn_order[0].set_deployment_data(_clone_army(GameManager._army_a))
+			turn_order[0].set_deployment_data(_clone_army(get_army_a()))
 		if turn_order[1].deployment_data.is_empty():
-			turn_order[1].set_deployment_data(_clone_army(GameManager._army_b))
+			turn_order[1].set_deployment_data(_clone_army(get_army_b()))
 
 	for usuario in turn_order:
 		usuario.living_units = 0
@@ -97,7 +135,7 @@ func _clone_army(army: ArmyRes) -> Array[CardArmyGroup]:
 	return copy
 
 func _on_unit_movement_requested(start: Vector2i, end: Vector2i) -> void:
-	var map_logic = GameManager.get_map()
+	var map_logic = get_map()
 	var unit = map_logic.get_tile_at(start).get_unit()
 	if unit.has_moved_this_turn:
 		print("La unidad ya se ha movido")
@@ -116,7 +154,7 @@ func _on_unit_movement_requested(start: Vector2i, end: Vector2i) -> void:
 
 
 func _on_unit_hability_use(tile: Vector2i, objectives: Array[Vector2i], hability: HabilityRes) -> void:
-	var map : MapGame = GameManager.get_map()
+	var map : MapGame = get_map()
 	var unit_source := map.get_tile_at(tile).get_unit()
 	if unit_source.has_used_hability_this_turn:
 		print("La unidad ya ha usado una habilidad activa!")
@@ -157,7 +195,7 @@ func start_deployment_phase() -> void:
 
 func end_deployment_phase() -> void:
 	is_deployment_phase = false
-	GameManager._app_state = GameManager.APP_STATE.IN_GAME
+	set_app_state(GameManager.APP_STATE.IN_GAME)
 	players_panel.set_phase_battle()
 
 	cards_panel.set_deployment_phase(false)
@@ -177,7 +215,7 @@ func _on_deploy_group(user_game: UserGame, group: CardArmyGroup, click_pos: Vect
 	if not user_game.deployment_data.has(group):
 		return false
 
-	var result: Dictionary = GameManager._gameMap.calculate_deployment(get_current_user_number(), group.n, click_pos)
+	var result: Dictionary = map_game.calculate_deployment(get_current_user_number(), group.n, click_pos)
 	if not result["is_valid"]:
 		return false
 
@@ -187,8 +225,8 @@ func _on_deploy_group(user_game: UserGame, group: CardArmyGroup, click_pos: Vect
 		var new_unit := UnitGame.new(group.cardType, user_game)
 		new_unit._owner = user_game
 
-		GameManager._gameMap.place_unit(new_unit, pos)
-		map_visualizer.draw_tile(pos.x, pos.y, GameManager._gameMap.get_tile_at(pos))
+		map_game.place_unit(new_unit, pos)
+		map_visualizer.draw_tile(pos.x, pos.y, map_game.get_tile_at(pos))
 
 		new_unit.died.connect(_on_unit_died)
 		
@@ -235,13 +273,13 @@ func _has_cards_to_deploy(user: UserGame) -> bool:
 	return user.has_deployment_cards()
 
 func _highlight_current_deployment_zone() -> void:
-	var zone_tiles:Array[Vector2i] = GameManager._gameMap.get_deployment_zone_tiles(get_current_user_number())
+	var zone_tiles:Array[Vector2i] = map_game.get_deployment_zone_tiles(get_current_user_number())
 	map_visualizer.show_deployment_zone(zone_tiles)
 
 
 #esta función se ejecuta caundo una unidad emite que ha muerto
 func _on_unit_died(unit: UnitGame, pos: Vector2i) -> void:
-	map_visualizer.remove_unit(pos, GameManager._gameMap.get_tile_at(pos))
+	map_visualizer.remove_unit(pos, map_game.get_tile_at(pos))
 
 	if tick_turn.is_connected(unit.advance_turn):
 			tick_turn.disconnect(unit.advance_turn)

--- a/godot/scripts/game/game_config.gd
+++ b/godot/scripts/game/game_config.gd
@@ -1,0 +1,15 @@
+class_name GameConfig
+extends Resource
+
+@export var user_a: UserRes
+@export var user_b: UserRes
+@export var army_a: ArmyRes
+@export var army_b: ArmyRes
+@export var map_res: MapRes
+
+func _init(p_user_a: UserRes = null, p_user_b: UserRes = null, p_map_res: MapRes = null, p_army_a: ArmyRes = null, p_army_b: ArmyRes = null) -> void:
+	user_a = p_user_a
+	user_b = p_user_b
+	army_a = p_army_a
+	army_b = p_army_b
+	map_res = p_map_res

--- a/godot/scripts/game/game_config.gd.uid
+++ b/godot/scripts/game/game_config.gd.uid
@@ -1,0 +1,1 @@
+uid://cjeswyp3ihdaq

--- a/godot/scripts/game/game_manager.gd
+++ b/godot/scripts/game/game_manager.gd
@@ -1,11 +1,8 @@
 extends Node
 
-@export var _user_a: UserRes
-@export var _user_b: UserRes
-@export var _army_a : ArmyRes
-@export var _army_b : ArmyRes
-@export var _gameMap: MapGame
-@export var _gameRes: GameResources
+@export var game_res: GameResources
+@export var app_state := APP_STATE.MENU_HUB
+@export var game_config: GameConfig
 
 var turn_manager: TurnManager
 signal phase_changed(phase: APP_STATE)
@@ -13,61 +10,48 @@ enum APP_STATE {
 	MENU_HUB,
 	IN_GAME,
 }
-@export var _app_state := APP_STATE.MENU_HUB
 
 
 func _init() -> void:
-	_gameRes = GameResources.load_from()
+	game_res = GameResources.load_from()
 	#temporal
 	#self.turn_manager= TurnManager.new()
-	_app_state = APP_STATE.MENU_HUB
-	#phase_changed.emit(_app_state)
+	app_state = APP_STATE.MENU_HUB
+	#phase_changed.emit(app_state)
 	set_users()
 
 
 
 func set_users() -> void:
-	var gr := GameResources.load_from() 
-	self._user_a = gr.users[0]
-	self._user_b = gr.users[1]
+	var gr := GameResources.load_from()
+	if game_config == null:
+		game_config = GameConfig.new()
+	game_config.user_a = gr.users[0]
+	game_config.user_b = gr.users[1]
 	
 ## Placeholder
 func start_game(playerA: UserRes, playerB:UserRes, map:MapRes, armyA: ArmyRes, armyB:ArmyRes) -> void:
-
-	self._user_a = playerA
-	self._user_b = playerB
-	self._gameMap = MapGame.new(map)
-	self._army_a = armyA
-	self._army_b = armyB
-
-	_app_state = APP_STATE.IN_GAME
+	game_config = GameConfig.new(playerA, playerB, map, armyA, armyB)
+	app_state = APP_STATE.IN_GAME
 
 	UiManager.cambiar_a_escena("juego")
 	
 
 # resetea la partida
 func restart_current_game() -> void:
-	var mapa_original = self._gameMap._mapRes
-	start_game(self._user_a, self._user_b, mapa_original, self._army_a, self._army_b)
+	if game_config == null:
+		return
+	var mapa_original = game_config.map_res
+	start_game(game_config.user_a, game_config.user_b, mapa_original, game_config.army_a, game_config.army_b)
 	
 ## Placeholder para obtener la info de configuración de una partida[br]
 ## Como puede ser los jugadores que se enfrentan, el mapa y ejercitos 
-func get_game_config() -> void:
-	pass
+func get_game_config() -> GameConfig:
+	return game_config
 	
 
-## Placeholder 
-func _get_mapRes() -> MapRes:
-	return self._gameMap._mapRes
-	
-func get_map() -> MapGame:
-	return self._gameMap
-	
 func get_game_resources() -> GameResources:
-	return self._gameRes
-
-func set_map(map_game:MapGame) -> void:
-	self._gameMap= map_game
+	return game_res
 	
 func get_turn_manager() -> TurnManager:
 	return self.turn_manager

--- a/godot/scripts/game/turn_actions/turn_deploy.gd
+++ b/godot/scripts/game/turn_actions/turn_deploy.gd
@@ -2,6 +2,7 @@ class_name TurnDeploy
 extends TurnAction
 
 var deploy_pos : Vector2i
+var card_res : CardRes
 var n : int
 
 static func create(player : UserGame, dpos: Vector2i, card_res: CardRes, n: int) -> TurnDeploy:

--- a/godot/scripts/game/unit_game.gd
+++ b/godot/scripts/game/unit_game.gd
@@ -92,12 +92,14 @@ func _proc_alter_states() -> void:
 			continue
 			
 		# Reutilizar esta funcion, un AlterState no deja de ser una minihabilidad
+		var tm := GameManager.get_turn_manager()
+		var map := tm.get_map()
 		var dest : Array[UnitGame] = []
 		if HabilityRes.inflicts_strict_self(alter.objective):
 			dest.append(self)
-		else:
-			dest.append_array(GameManager.get_map().get_units_range(_tile.get_position(), alter.radius, alter.objective) \
-					.map(func (x: Vector2i): return GameManager.get_map().get_tile_at(x).get_unit()) as Array[UnitGame])
+		elif map:
+			dest.append_array(map.get_units_range(_tile.get_position(), alter.radius, alter.objective) \
+					.map(func (x: Vector2i): return map.get_tile_at(x).get_unit()) as Array[UnitGame])
 		for obj in dest:
 			_apply_hab(alter.stat, alter.type, alter.value, obj)
 		
@@ -105,10 +107,13 @@ func _proc_alter_states() -> void:
 ## se debe llamar cada turno del jugador
 ## Se debe vincular con TurnManager
 func advance_turn() -> void:
-	if GameManager.get_turn_manager().get_current_user() != _owner:
+	var tm := GameManager.get_turn_manager()
+	if tm == null:
+		return
+	if tm.get_current_user() != _owner:
 		return
 	# Si es despliegue ignoramos esta llamadas
-	if GameManager._app_state != GameManager.APP_STATE.IN_GAME:
+	if tm.get_app_state() != GameManager.APP_STATE.IN_GAME:
 		return
 	_tick()
 	
@@ -241,7 +246,11 @@ func get_available_habilities() -> Array[HabilityRes]:
 		if cd > 0:
 			continue
 			
-		if GameManager.get_map().get_units_range(_tile.get_position(), key.radius, key.objective).size() == 0:
+		var tm := GameManager.get_turn_manager()
+		var map := tm.get_map()
+		if map == null:
+			continue
+		if map.get_units_range(_tile.get_position(), key.radius, key.objective).size() == 0:
 			continue
 		
 		if key.manaCost > self.mana:

--- a/godot/test/scenes/test_map_game.gd
+++ b/godot/test/scenes/test_map_game.gd
@@ -6,7 +6,10 @@ const map_scene: String = "res://scenes/ingame/ingame_map.tscn"
 
 func test_visualizer() -> void:
 	var map := create_test_map()
-	GameManager._gameMap = map
+	var tm := TurnManager.new()
+	GameManager.register_turn_manager(tm)
+	GameManager.game_config = GameConfig.new(null, null, map._mapRes, null, null)
+	tm.set_map(map)
 	var prev_add_target = gut.add_children_to
 	gut.add_children_to = get_tree().get_root()
 	var scene := preload(map_scene)
@@ -26,11 +29,13 @@ func test_visualizer() -> void:
 func test_hability_applies_to_bars() -> void:
 	var gr := GameResources.load_from()
 	var map := create_test_map()
-	GameManager._gameMap = map
-	GameManager._user_a = gr.users[0]
-	GameManager._user_b = gr.users[1]
-	GameManager._army_a = gr.users[0].obtener_ejercito_activo()
-	GameManager._army_b = gr.users[1].obtener_ejercito_activo()
+	GameManager.game_config = GameConfig.new(
+		gr.users[0],
+		gr.users[1],
+		map._mapRes,
+		gr.users[0].obtener_ejercito_activo(),
+		gr.users[1].obtener_ejercito_activo()
+	)
 
 	# Usar game_scene.tscn que incluye TurnManager
 	var prev_add_target = gut.add_children_to
@@ -40,6 +45,7 @@ func test_hability_applies_to_bars() -> void:
 	var user_b_game := UserGame.new(gr.users[1])
 	instance.turn_order = [user_a_game, user_b_game]
 	instance.turn_number = 0
+	instance.set_map(map)
 	add_child_autoqfree(instance)
 
 	await wait_until(func(): return instance.is_inside_tree(), 5)
@@ -57,6 +63,8 @@ func test_hability_applies_to_bars() -> void:
 	card_attacker.mana = 50
 	card_attacker.speed = 3
 	card_attacker.dodge = 10.0
+	card_attacker.img = get_unit_texture("res://assets/tiles/Legacy-Fantasy - High Forest 2.0/Legacy-Fantasy - High Forest 2.3/Character/Idle/Idle-Sheet.png")
+	card_attacker.portrait = get_unit_texture("res://assets/tiles/Legacy-Fantasy - High Forest 2.0/Legacy-Fantasy - High Forest 2.3/Character/Idle/Idle-Sheet.png")
 	card_attacker.habilities = [_create_physical_attack()] as Array[HabilityRes]
 	card_attacker.resistances = {} as Dictionary[AttackType, int]
 
@@ -66,6 +74,8 @@ func test_hability_applies_to_bars() -> void:
 	card_target.mana = 40
 	card_target.speed = 2
 	card_target.dodge = 5.0
+	card_target.img = get_unit_texture("res://assets/tiles/Legacy-Fantasy - High Forest 2.0/Legacy-Fantasy - High Forest 2.3/Character/Idle/Idle-Sheet.png")
+	card_target.portrait = get_unit_texture("res://assets/tiles/Legacy-Fantasy - High Forest 2.0/Legacy-Fantasy - High Forest 2.3/Character/Idle/Idle-Sheet.png")
 	card_target.habilities = [] as Array[HabilityRes]
 	card_target.resistances = {} as Dictionary[AttackType, int]
 
@@ -439,6 +449,8 @@ func test_bars_react_to_signals() -> void:
 	card.name = "Test Unit"
 	card.hp = 100
 	card.mana = 50
+	card.img = get_unit_texture("res://assets/tiles/Legacy-Fantasy - High Forest 2.0/Legacy-Fantasy - High Forest 2.3/Character/Idle/Idle-Sheet.png")
+	card.portrait = get_unit_texture("res://assets/tiles/Legacy-Fantasy - High Forest 2.0/Legacy-Fantasy - High Forest 2.3/Character/Idle/Idle-Sheet.png")
 	card.habilities = [] as Array[HabilityRes]
 	card.resistances = {} as Dictionary[AttackType, int]
 	
@@ -447,7 +459,7 @@ func test_bars_react_to_signals() -> void:
 	# Instanciar escena
 	var gr := GameResources.load_from()
 	var map := create_test_map()
-	GameManager._gameMap = map
+	GameManager.game_config = GameConfig.new(null, null, map._mapRes, null, null)
 	
 	var prev_add_target = gut.add_children_to
 	gut.add_children_to = get_tree().get_root()
@@ -456,6 +468,7 @@ func test_bars_react_to_signals() -> void:
 	var user_b_game := UserGame.new(gr.users[1])
 	instance.turn_order = [user_a_game, user_b_game]
 	instance.turn_number = 0
+	instance.set_map(map)
 	add_child_autoqfree(instance)
 	
 	await wait_until(func(): return instance.is_inside_tree(), 5)

--- a/godot/test/scenes/test_real_resources_2.gd
+++ b/godot/test/scenes/test_real_resources_2.gd
@@ -7,8 +7,13 @@ func test_sandbox_interactivo_movimiento() -> void:
 	var gr = GameResources.load_from()
 	var user_a = gr.users[0]
 	var user_b = gr.users[1]
-	
-	GameManager._gameMap = MapGame.new(gr.maps[0])
+	GameManager.game_config = GameConfig.new(
+		user_a,
+		user_b,
+		gr.maps[0],
+		user_a.obtener_ejercito_activo(),
+		user_b.obtener_ejercito_activo()
+	)
 	
 	var map_instance = load(MAP_SCENE_PATH).instantiate()
 	add_child_autoqfree(map_instance)

--- a/godot/test/test_res/all_test_resources.tres
+++ b/godot/test/test_res/all_test_resources.tres
@@ -1308,12 +1308,652 @@ tamY = 4
 mapData = Array[Array]([Array[ExtResource("12_17yll")]([SubResource("Resource_td7my"), SubResource("Resource_luc6k"), SubResource("Resource_hjh4y"), SubResource("Resource_q88h0"), SubResource("Resource_6vh4f")]), Array[ExtResource("12_17yll")]([SubResource("Resource_bxif7"), SubResource("Resource_4dj12"), SubResource("Resource_7lavj"), SubResource("Resource_t4mxy"), SubResource("Resource_040jv")]), Array[ExtResource("12_17yll")]([SubResource("Resource_2yum1"), SubResource("Resource_3wvcv"), SubResource("Resource_75ua1"), SubResource("Resource_eqpix"), SubResource("Resource_gywua")]), Array[ExtResource("12_17yll")]([SubResource("Resource_yi6wb"), SubResource("Resource_3njbj"), SubResource("Resource_45m6o"), SubResource("Resource_v1tme"), SubResource("Resource_desx7")])])
 uid = 1
 
+[sub_resource type="Resource" id="Resource_20ku2"]
+script = ExtResource("12_17yll")
+height = 1
+type = ExtResource("22_ptf7x")
+uid = 1
+
+[sub_resource type="Resource" id="Resource_262nd"]
+script = ExtResource("12_17yll")
+height = 1
+type = ExtResource("22_ptf7x")
+uid = 2
+
+[sub_resource type="Resource" id="Resource_veigo"]
+script = ExtResource("12_17yll")
+height = 1
+type = ExtResource("22_ptf7x")
+uid = 3
+
+[sub_resource type="Resource" id="Resource_0klvm"]
+script = ExtResource("12_17yll")
+height = 1
+type = ExtResource("22_ptf7x")
+uid = 4
+
+[sub_resource type="Resource" id="Resource_gc3x4"]
+script = ExtResource("12_17yll")
+height = 100
+type = ExtResource("22_ptf7x")
+uid = 5
+
+[sub_resource type="Resource" id="Resource_m6dpe"]
+script = ExtResource("12_17yll")
+height = 1
+type = ExtResource("22_ptf7x")
+uid = 6
+
+[sub_resource type="Resource" id="Resource_yrtef"]
+script = ExtResource("12_17yll")
+height = 1
+type = ExtResource("23_uu4tw")
+uid = 7
+
+[sub_resource type="Resource" id="Resource_g8eoj"]
+script = ExtResource("12_17yll")
+height = 1
+type = ExtResource("22_ptf7x")
+uid = 8
+
+[sub_resource type="Resource" id="Resource_eqert"]
+script = ExtResource("12_17yll")
+height = 1
+type = ExtResource("23_uu4tw")
+uid = 9
+
+[sub_resource type="Resource" id="Resource_wsrre"]
+script = ExtResource("12_17yll")
+height = 1
+type = ExtResource("22_ptf7x")
+uid = 10
+
+[sub_resource type="Resource" id="Resource_xeemb"]
+script = ExtResource("12_17yll")
+height = 1
+type = ExtResource("22_ptf7x")
+uid = 11
+
+[sub_resource type="Resource" id="Resource_gd620"]
+script = ExtResource("12_17yll")
+height = 1
+type = ExtResource("23_uu4tw")
+uid = 12
+
+[sub_resource type="Resource" id="Resource_jygdc"]
+script = ExtResource("12_17yll")
+height = 1
+type = ExtResource("22_ptf7x")
+uid = 13
+
+[sub_resource type="Resource" id="Resource_66rns"]
+script = ExtResource("12_17yll")
+height = 1
+type = ExtResource("23_uu4tw")
+uid = 14
+
+[sub_resource type="Resource" id="Resource_wvk0v"]
+script = ExtResource("12_17yll")
+height = 1
+type = ExtResource("22_ptf7x")
+uid = 15
+
+[sub_resource type="Resource" id="Resource_l3ho3"]
+script = ExtResource("12_17yll")
+height = 1
+type = ExtResource("22_ptf7x")
+uid = 16
+
+[sub_resource type="Resource" id="Resource_rw2bp"]
+script = ExtResource("12_17yll")
+height = 1
+type = ExtResource("22_ptf7x")
+uid = 17
+
+[sub_resource type="Resource" id="Resource_mvwp2"]
+script = ExtResource("12_17yll")
+height = 1
+type = ExtResource("22_ptf7x")
+uid = 18
+
+[sub_resource type="Resource" id="Resource_vs8k4"]
+script = ExtResource("12_17yll")
+height = 1
+type = ExtResource("22_ptf7x")
+uid = 19
+
+[sub_resource type="Resource" id="Resource_1dvit"]
+script = ExtResource("12_17yll")
+height = 100
+type = ExtResource("22_ptf7x")
+uid = 20
+
+[sub_resource type="Resource" id="Resource_6to0j"]
+script = ExtResource("7_v3wyj")
+name = &"test_map_01"
+tamX = 5
+tamY = 4
+mapData = Array[Array]([Array[ExtResource("12_17yll")]([SubResource("Resource_20ku2"), SubResource("Resource_262nd"), SubResource("Resource_veigo"), SubResource("Resource_0klvm"), SubResource("Resource_gc3x4")]), Array[ExtResource("12_17yll")]([SubResource("Resource_m6dpe"), SubResource("Resource_yrtef"), SubResource("Resource_g8eoj"), SubResource("Resource_eqert"), SubResource("Resource_wsrre")]), Array[ExtResource("12_17yll")]([SubResource("Resource_xeemb"), SubResource("Resource_gd620"), SubResource("Resource_jygdc"), SubResource("Resource_66rns"), SubResource("Resource_wvk0v")]), Array[ExtResource("12_17yll")]([SubResource("Resource_l3ho3"), SubResource("Resource_rw2bp"), SubResource("Resource_mvwp2"), SubResource("Resource_vs8k4"), SubResource("Resource_1dvit")])])
+uid = 1
+
+[sub_resource type="Resource" id="Resource_1ftx2"]
+script = ExtResource("12_17yll")
+height = 1
+type = ExtResource("22_ptf7x")
+uid = 1
+
+[sub_resource type="Resource" id="Resource_rle4a"]
+script = ExtResource("12_17yll")
+height = 1
+type = ExtResource("22_ptf7x")
+uid = 2
+
+[sub_resource type="Resource" id="Resource_s034x"]
+script = ExtResource("12_17yll")
+height = 1
+type = ExtResource("22_ptf7x")
+uid = 3
+
+[sub_resource type="Resource" id="Resource_774p3"]
+script = ExtResource("12_17yll")
+height = 1
+type = ExtResource("22_ptf7x")
+uid = 4
+
+[sub_resource type="Resource" id="Resource_h47s1"]
+script = ExtResource("12_17yll")
+height = 100
+type = ExtResource("22_ptf7x")
+uid = 5
+
+[sub_resource type="Resource" id="Resource_gm20s"]
+script = ExtResource("12_17yll")
+height = 1
+type = ExtResource("22_ptf7x")
+uid = 6
+
+[sub_resource type="Resource" id="Resource_rxl5e"]
+script = ExtResource("12_17yll")
+height = 1
+type = ExtResource("23_uu4tw")
+uid = 7
+
+[sub_resource type="Resource" id="Resource_tj536"]
+script = ExtResource("12_17yll")
+height = 1
+type = ExtResource("22_ptf7x")
+uid = 8
+
+[sub_resource type="Resource" id="Resource_ip3qb"]
+script = ExtResource("12_17yll")
+height = 1
+type = ExtResource("23_uu4tw")
+uid = 9
+
+[sub_resource type="Resource" id="Resource_3hux5"]
+script = ExtResource("12_17yll")
+height = 1
+type = ExtResource("22_ptf7x")
+uid = 10
+
+[sub_resource type="Resource" id="Resource_hsv6v"]
+script = ExtResource("12_17yll")
+height = 1
+type = ExtResource("22_ptf7x")
+uid = 11
+
+[sub_resource type="Resource" id="Resource_ygk56"]
+script = ExtResource("12_17yll")
+height = 1
+type = ExtResource("23_uu4tw")
+uid = 12
+
+[sub_resource type="Resource" id="Resource_n3486"]
+script = ExtResource("12_17yll")
+height = 1
+type = ExtResource("22_ptf7x")
+uid = 13
+
+[sub_resource type="Resource" id="Resource_mp5m6"]
+script = ExtResource("12_17yll")
+height = 1
+type = ExtResource("23_uu4tw")
+uid = 14
+
+[sub_resource type="Resource" id="Resource_e74s1"]
+script = ExtResource("12_17yll")
+height = 1
+type = ExtResource("22_ptf7x")
+uid = 15
+
+[sub_resource type="Resource" id="Resource_1tcdf"]
+script = ExtResource("12_17yll")
+height = 1
+type = ExtResource("22_ptf7x")
+uid = 16
+
+[sub_resource type="Resource" id="Resource_utmnf"]
+script = ExtResource("12_17yll")
+height = 1
+type = ExtResource("22_ptf7x")
+uid = 17
+
+[sub_resource type="Resource" id="Resource_dckuw"]
+script = ExtResource("12_17yll")
+height = 1
+type = ExtResource("22_ptf7x")
+uid = 18
+
+[sub_resource type="Resource" id="Resource_br88g"]
+script = ExtResource("12_17yll")
+height = 1
+type = ExtResource("22_ptf7x")
+uid = 19
+
+[sub_resource type="Resource" id="Resource_i3qua"]
+script = ExtResource("12_17yll")
+height = 100
+type = ExtResource("22_ptf7x")
+uid = 20
+
+[sub_resource type="Resource" id="Resource_h4j7i"]
+script = ExtResource("7_v3wyj")
+name = &"test_map_01"
+tamX = 5
+tamY = 4
+mapData = Array[Array]([Array[ExtResource("12_17yll")]([SubResource("Resource_1ftx2"), SubResource("Resource_rle4a"), SubResource("Resource_s034x"), SubResource("Resource_774p3"), SubResource("Resource_h47s1")]), Array[ExtResource("12_17yll")]([SubResource("Resource_gm20s"), SubResource("Resource_rxl5e"), SubResource("Resource_tj536"), SubResource("Resource_ip3qb"), SubResource("Resource_3hux5")]), Array[ExtResource("12_17yll")]([SubResource("Resource_hsv6v"), SubResource("Resource_ygk56"), SubResource("Resource_n3486"), SubResource("Resource_mp5m6"), SubResource("Resource_e74s1")]), Array[ExtResource("12_17yll")]([SubResource("Resource_1tcdf"), SubResource("Resource_utmnf"), SubResource("Resource_dckuw"), SubResource("Resource_br88g"), SubResource("Resource_i3qua")])])
+uid = 1
+
+[sub_resource type="Resource" id="Resource_wibv7"]
+script = ExtResource("12_17yll")
+height = 1
+type = ExtResource("22_ptf7x")
+uid = 1
+
+[sub_resource type="Resource" id="Resource_h7ghe"]
+script = ExtResource("12_17yll")
+height = 1
+type = ExtResource("22_ptf7x")
+uid = 2
+
+[sub_resource type="Resource" id="Resource_3oc6c"]
+script = ExtResource("12_17yll")
+height = 1
+type = ExtResource("22_ptf7x")
+uid = 3
+
+[sub_resource type="Resource" id="Resource_ow5rw"]
+script = ExtResource("12_17yll")
+height = 1
+type = ExtResource("22_ptf7x")
+uid = 4
+
+[sub_resource type="Resource" id="Resource_265xc"]
+script = ExtResource("12_17yll")
+height = 100
+type = ExtResource("22_ptf7x")
+uid = 5
+
+[sub_resource type="Resource" id="Resource_u2rho"]
+script = ExtResource("12_17yll")
+height = 1
+type = ExtResource("22_ptf7x")
+uid = 6
+
+[sub_resource type="Resource" id="Resource_7lcfj"]
+script = ExtResource("12_17yll")
+height = 1
+type = ExtResource("23_uu4tw")
+uid = 7
+
+[sub_resource type="Resource" id="Resource_td11i"]
+script = ExtResource("12_17yll")
+height = 1
+type = ExtResource("22_ptf7x")
+uid = 8
+
+[sub_resource type="Resource" id="Resource_54w5w"]
+script = ExtResource("12_17yll")
+height = 1
+type = ExtResource("23_uu4tw")
+uid = 9
+
+[sub_resource type="Resource" id="Resource_ac2ym"]
+script = ExtResource("12_17yll")
+height = 1
+type = ExtResource("22_ptf7x")
+uid = 10
+
+[sub_resource type="Resource" id="Resource_2pwo8"]
+script = ExtResource("12_17yll")
+height = 1
+type = ExtResource("22_ptf7x")
+uid = 11
+
+[sub_resource type="Resource" id="Resource_anrm2"]
+script = ExtResource("12_17yll")
+height = 1
+type = ExtResource("23_uu4tw")
+uid = 12
+
+[sub_resource type="Resource" id="Resource_7mnyv"]
+script = ExtResource("12_17yll")
+height = 1
+type = ExtResource("22_ptf7x")
+uid = 13
+
+[sub_resource type="Resource" id="Resource_s3aol"]
+script = ExtResource("12_17yll")
+height = 1
+type = ExtResource("23_uu4tw")
+uid = 14
+
+[sub_resource type="Resource" id="Resource_a48gp"]
+script = ExtResource("12_17yll")
+height = 1
+type = ExtResource("22_ptf7x")
+uid = 15
+
+[sub_resource type="Resource" id="Resource_1b0c0"]
+script = ExtResource("12_17yll")
+height = 1
+type = ExtResource("22_ptf7x")
+uid = 16
+
+[sub_resource type="Resource" id="Resource_qden2"]
+script = ExtResource("12_17yll")
+height = 1
+type = ExtResource("22_ptf7x")
+uid = 17
+
+[sub_resource type="Resource" id="Resource_falwg"]
+script = ExtResource("12_17yll")
+height = 1
+type = ExtResource("22_ptf7x")
+uid = 18
+
+[sub_resource type="Resource" id="Resource_xv1sj"]
+script = ExtResource("12_17yll")
+height = 1
+type = ExtResource("22_ptf7x")
+uid = 19
+
+[sub_resource type="Resource" id="Resource_gm0u1"]
+script = ExtResource("12_17yll")
+height = 100
+type = ExtResource("22_ptf7x")
+uid = 20
+
+[sub_resource type="Resource" id="Resource_xowoa"]
+script = ExtResource("7_v3wyj")
+name = &"test_map_01"
+tamX = 5
+tamY = 4
+mapData = Array[Array]([Array[ExtResource("12_17yll")]([SubResource("Resource_wibv7"), SubResource("Resource_h7ghe"), SubResource("Resource_3oc6c"), SubResource("Resource_ow5rw"), SubResource("Resource_265xc")]), Array[ExtResource("12_17yll")]([SubResource("Resource_u2rho"), SubResource("Resource_7lcfj"), SubResource("Resource_td11i"), SubResource("Resource_54w5w"), SubResource("Resource_ac2ym")]), Array[ExtResource("12_17yll")]([SubResource("Resource_2pwo8"), SubResource("Resource_anrm2"), SubResource("Resource_7mnyv"), SubResource("Resource_s3aol"), SubResource("Resource_a48gp")]), Array[ExtResource("12_17yll")]([SubResource("Resource_1b0c0"), SubResource("Resource_qden2"), SubResource("Resource_falwg"), SubResource("Resource_xv1sj"), SubResource("Resource_gm0u1")])])
+uid = 1
+
+[sub_resource type="Resource" id="Resource_1t8uw"]
+script = ExtResource("12_17yll")
+height = 1
+type = ExtResource("22_ptf7x")
+uid = 1
+
+[sub_resource type="Resource" id="Resource_62jf5"]
+script = ExtResource("12_17yll")
+height = 1
+type = ExtResource("22_ptf7x")
+uid = 2
+
+[sub_resource type="Resource" id="Resource_raqui"]
+script = ExtResource("12_17yll")
+height = 1
+type = ExtResource("22_ptf7x")
+uid = 3
+
+[sub_resource type="Resource" id="Resource_76gbv"]
+script = ExtResource("12_17yll")
+height = 1
+type = ExtResource("22_ptf7x")
+uid = 4
+
+[sub_resource type="Resource" id="Resource_aq4gh"]
+script = ExtResource("12_17yll")
+height = 100
+type = ExtResource("22_ptf7x")
+uid = 5
+
+[sub_resource type="Resource" id="Resource_3ardk"]
+script = ExtResource("12_17yll")
+height = 1
+type = ExtResource("22_ptf7x")
+uid = 6
+
+[sub_resource type="Resource" id="Resource_p67lv"]
+script = ExtResource("12_17yll")
+height = 1
+type = ExtResource("23_uu4tw")
+uid = 7
+
+[sub_resource type="Resource" id="Resource_yrjof"]
+script = ExtResource("12_17yll")
+height = 1
+type = ExtResource("22_ptf7x")
+uid = 8
+
+[sub_resource type="Resource" id="Resource_8q7bk"]
+script = ExtResource("12_17yll")
+height = 1
+type = ExtResource("23_uu4tw")
+uid = 9
+
+[sub_resource type="Resource" id="Resource_5a5bg"]
+script = ExtResource("12_17yll")
+height = 1
+type = ExtResource("22_ptf7x")
+uid = 10
+
+[sub_resource type="Resource" id="Resource_1oivn"]
+script = ExtResource("12_17yll")
+height = 1
+type = ExtResource("22_ptf7x")
+uid = 11
+
+[sub_resource type="Resource" id="Resource_fvaq8"]
+script = ExtResource("12_17yll")
+height = 1
+type = ExtResource("23_uu4tw")
+uid = 12
+
+[sub_resource type="Resource" id="Resource_ar1fu"]
+script = ExtResource("12_17yll")
+height = 1
+type = ExtResource("22_ptf7x")
+uid = 13
+
+[sub_resource type="Resource" id="Resource_j33lq"]
+script = ExtResource("12_17yll")
+height = 1
+type = ExtResource("23_uu4tw")
+uid = 14
+
+[sub_resource type="Resource" id="Resource_wj4vu"]
+script = ExtResource("12_17yll")
+height = 1
+type = ExtResource("22_ptf7x")
+uid = 15
+
+[sub_resource type="Resource" id="Resource_ysk0p"]
+script = ExtResource("12_17yll")
+height = 1
+type = ExtResource("22_ptf7x")
+uid = 16
+
+[sub_resource type="Resource" id="Resource_kvrh8"]
+script = ExtResource("12_17yll")
+height = 1
+type = ExtResource("22_ptf7x")
+uid = 17
+
+[sub_resource type="Resource" id="Resource_7nbqc"]
+script = ExtResource("12_17yll")
+height = 1
+type = ExtResource("22_ptf7x")
+uid = 18
+
+[sub_resource type="Resource" id="Resource_543lg"]
+script = ExtResource("12_17yll")
+height = 1
+type = ExtResource("22_ptf7x")
+uid = 19
+
+[sub_resource type="Resource" id="Resource_2sfep"]
+script = ExtResource("12_17yll")
+height = 100
+type = ExtResource("22_ptf7x")
+uid = 20
+
+[sub_resource type="Resource" id="Resource_yqpso"]
+script = ExtResource("7_v3wyj")
+name = &"test_map_01"
+tamX = 5
+tamY = 4
+mapData = Array[Array]([Array[ExtResource("12_17yll")]([SubResource("Resource_1t8uw"), SubResource("Resource_62jf5"), SubResource("Resource_raqui"), SubResource("Resource_76gbv"), SubResource("Resource_aq4gh")]), Array[ExtResource("12_17yll")]([SubResource("Resource_3ardk"), SubResource("Resource_p67lv"), SubResource("Resource_yrjof"), SubResource("Resource_8q7bk"), SubResource("Resource_5a5bg")]), Array[ExtResource("12_17yll")]([SubResource("Resource_1oivn"), SubResource("Resource_fvaq8"), SubResource("Resource_ar1fu"), SubResource("Resource_j33lq"), SubResource("Resource_wj4vu")]), Array[ExtResource("12_17yll")]([SubResource("Resource_ysk0p"), SubResource("Resource_kvrh8"), SubResource("Resource_7nbqc"), SubResource("Resource_543lg"), SubResource("Resource_2sfep")])])
+uid = 1
+
+[sub_resource type="Resource" id="Resource_qgpw8"]
+script = ExtResource("12_17yll")
+height = 1
+type = ExtResource("22_ptf7x")
+uid = 1
+
+[sub_resource type="Resource" id="Resource_v8iyn"]
+script = ExtResource("12_17yll")
+height = 1
+type = ExtResource("22_ptf7x")
+uid = 2
+
+[sub_resource type="Resource" id="Resource_hjwky"]
+script = ExtResource("12_17yll")
+height = 1
+type = ExtResource("22_ptf7x")
+uid = 3
+
+[sub_resource type="Resource" id="Resource_ocwja"]
+script = ExtResource("12_17yll")
+height = 1
+type = ExtResource("22_ptf7x")
+uid = 4
+
+[sub_resource type="Resource" id="Resource_74tpc"]
+script = ExtResource("12_17yll")
+height = 100
+type = ExtResource("22_ptf7x")
+uid = 5
+
+[sub_resource type="Resource" id="Resource_k1q1x"]
+script = ExtResource("12_17yll")
+height = 1
+type = ExtResource("22_ptf7x")
+uid = 6
+
+[sub_resource type="Resource" id="Resource_yotoj"]
+script = ExtResource("12_17yll")
+height = 1
+type = ExtResource("23_uu4tw")
+uid = 7
+
+[sub_resource type="Resource" id="Resource_x6hyq"]
+script = ExtResource("12_17yll")
+height = 1
+type = ExtResource("22_ptf7x")
+uid = 8
+
+[sub_resource type="Resource" id="Resource_yo4a7"]
+script = ExtResource("12_17yll")
+height = 1
+type = ExtResource("23_uu4tw")
+uid = 9
+
+[sub_resource type="Resource" id="Resource_p6waj"]
+script = ExtResource("12_17yll")
+height = 1
+type = ExtResource("22_ptf7x")
+uid = 10
+
+[sub_resource type="Resource" id="Resource_cg8v2"]
+script = ExtResource("12_17yll")
+height = 1
+type = ExtResource("22_ptf7x")
+uid = 11
+
+[sub_resource type="Resource" id="Resource_abnwj"]
+script = ExtResource("12_17yll")
+height = 1
+type = ExtResource("23_uu4tw")
+uid = 12
+
+[sub_resource type="Resource" id="Resource_p4xfo"]
+script = ExtResource("12_17yll")
+height = 1
+type = ExtResource("22_ptf7x")
+uid = 13
+
+[sub_resource type="Resource" id="Resource_ckx1e"]
+script = ExtResource("12_17yll")
+height = 1
+type = ExtResource("23_uu4tw")
+uid = 14
+
+[sub_resource type="Resource" id="Resource_1b1mx"]
+script = ExtResource("12_17yll")
+height = 1
+type = ExtResource("22_ptf7x")
+uid = 15
+
+[sub_resource type="Resource" id="Resource_exj1c"]
+script = ExtResource("12_17yll")
+height = 1
+type = ExtResource("22_ptf7x")
+uid = 16
+
+[sub_resource type="Resource" id="Resource_d2nah"]
+script = ExtResource("12_17yll")
+height = 1
+type = ExtResource("22_ptf7x")
+uid = 17
+
+[sub_resource type="Resource" id="Resource_5dj4o"]
+script = ExtResource("12_17yll")
+height = 1
+type = ExtResource("22_ptf7x")
+uid = 18
+
+[sub_resource type="Resource" id="Resource_qpfcu"]
+script = ExtResource("12_17yll")
+height = 1
+type = ExtResource("22_ptf7x")
+uid = 19
+
+[sub_resource type="Resource" id="Resource_foy8y"]
+script = ExtResource("12_17yll")
+height = 100
+type = ExtResource("22_ptf7x")
+uid = 20
+
+[sub_resource type="Resource" id="Resource_lb6p8"]
+script = ExtResource("7_v3wyj")
+name = &"test_map_01"
+tamX = 5
+tamY = 4
+mapData = Array[Array]([Array[ExtResource("12_17yll")]([SubResource("Resource_qgpw8"), SubResource("Resource_v8iyn"), SubResource("Resource_hjwky"), SubResource("Resource_ocwja"), SubResource("Resource_74tpc")]), Array[ExtResource("12_17yll")]([SubResource("Resource_k1q1x"), SubResource("Resource_yotoj"), SubResource("Resource_x6hyq"), SubResource("Resource_yo4a7"), SubResource("Resource_p6waj")]), Array[ExtResource("12_17yll")]([SubResource("Resource_cg8v2"), SubResource("Resource_abnwj"), SubResource("Resource_p4xfo"), SubResource("Resource_ckx1e"), SubResource("Resource_1b1mx")]), Array[ExtResource("12_17yll")]([SubResource("Resource_exj1c"), SubResource("Resource_d2nah"), SubResource("Resource_5dj4o"), SubResource("Resource_qpfcu"), SubResource("Resource_foy8y")])])
+uid = 1
+
 [resource]
 script = ExtResource("8_2obhi")
 users = Array[ExtResource("13_b8vvb")]([ExtResource("16_v3wyj"), ExtResource("17_2obhi")])
 cards = Array[ExtResource("5_kdr8l")]([ExtResource("6_kdr8l"), ExtResource("7_2ym1e")])
 habilities = Array[ExtResource("6_2ym1e")]([ExtResource("11_ptf7x"), ExtResource("12_uu4tw"), ExtResource("13_yk6kr"), ExtResource("14_j6ham"), ExtResource("15_7b4bf"), ExtResource("16_838kx")])
 tile_types = Array[ExtResource("11_qx8eh")]([ExtResource("22_ptf7x"), ExtResource("23_uu4tw")])
-maps = Array[ExtResource("7_v3wyj")]([SubResource("Resource_jgcne"), SubResource("Resource_xiqqn"), SubResource("Resource_kfe8r"), SubResource("Resource_ihe70"), SubResource("Resource_71e67"), SubResource("Resource_8i3xi"), SubResource("Resource_ba5bm"), SubResource("Resource_e668n"), SubResource("Resource_4enc5"), SubResource("Resource_76arf")])
+maps = Array[ExtResource("7_v3wyj")]([SubResource("Resource_jgcne"), SubResource("Resource_xiqqn"), SubResource("Resource_kfe8r"), SubResource("Resource_ihe70"), SubResource("Resource_71e67"), SubResource("Resource_8i3xi"), SubResource("Resource_ba5bm"), SubResource("Resource_e668n"), SubResource("Resource_4enc5"), SubResource("Resource_76arf"), SubResource("Resource_6to0j"), SubResource("Resource_h4j7i"), SubResource("Resource_xowoa"), SubResource("Resource_yqpso"), SubResource("Resource_lb6p8")])
 alter_states = Array[ExtResource("1_0ys6n")]([ExtResource("2_b8vvb"), ExtResource("3_eabsc")])
 metadata/_custom_type_script = "uid://c1o5v8x6fs24v"

--- a/godot/test/test_res/card_melee.tres
+++ b/godot/test/test_res/card_melee.tres
@@ -9,6 +9,7 @@
 [ext_resource type="Resource" uid="uid://ck5bwmcsoj647" path="res://test/test_res/hab_set_kaboom.tres" id="4_yy4e5"]
 [ext_resource type="Resource" uid="uid://b7brrj7g17r0f" path="res://test/test_res/hab_cond_hipercura.tres" id="5_yy4e5"]
 [ext_resource type="Resource" uid="uid://be8g0osouqn7r" path="res://test/test_res/hab_cond_megacura.tres" id="6_1bhc3"]
+[ext_resource type="Texture2D" uid="uid://cfhl3bp06jbqv" path="res://assets/sprites/imagenes_de_cartas/elfo.jpg" id="7_f6foa"]
 
 [resource]
 script = ExtResource("3_5je53")
@@ -17,5 +18,7 @@ desc = "test melee"
 hp = 20
 mana = 5
 speed = 4
+portrait = ExtResource("7_f6foa")
+img = ExtResource("7_f6foa")
 habilities = Array[ExtResource("1_ct0dh")]([ExtResource("2_5je53"), ExtResource("3_ll81n"), ExtResource("4_yy4e5"), ExtResource("5_yy4e5"), ExtResource("6_1bhc3")])
 metadata/_custom_type_script = "uid://bf6xxxd2rqod0"

--- a/godot/test/test_res/card_ranged.tres
+++ b/godot/test/test_res/card_ranged.tres
@@ -8,6 +8,7 @@
 [ext_resource type="Resource" uid="uid://duyb5pv17toxt" path="res://test/test_res/hab_bomba_psiquica.tres" id="4_0nbpr"]
 [ext_resource type="Script" uid="uid://1txoxg5iohxc" path="res://scripts/resources/card_type_res.gd" id="4_b26a2"]
 [ext_resource type="Resource" uid="uid://drlxjkpuo8uo0" path="res://test/test_res/hab_cond_daño_altura.tres" id="5_0nbpr"]
+[ext_resource type="Texture2D" uid="uid://b0yy2cwl13n5o" path="res://assets/sprites/imagenes_de_cartas/esqueleto.jpg" id="6_iwaig"]
 
 [resource]
 script = ExtResource("3_gtena")
@@ -16,5 +17,7 @@ desc = "test ranged"
 hp = 10
 mana = 15
 speed = 7
+portrait = ExtResource("6_iwaig")
+img = ExtResource("6_iwaig")
 habilities = Array[ExtResource("1_pv25n")]([ExtResource("2_gtena"), ExtResource("3_b26a2"), ExtResource("4_0nbpr"), ExtResource("5_0nbpr")])
 metadata/_custom_type_script = "uid://bf6xxxd2rqod0"

--- a/godot/test/test_res/map_test.tres
+++ b/godot/test/test_res/map_test.tres
@@ -1,9 +1,9 @@
-[gd_resource type="Resource" script_class="MapRes" format=3 uid="uid://5il77k6mpltn"]
+[gd_resource type="Resource" script_class="MapRes" format=3]
 
-[ext_resource type="Script" uid="uid://bmy17ix6av5bg" path="res://scripts/resources/tile_res.gd" id="1_co4aq"]
-[ext_resource type="Script" uid="uid://808yjkcnb362" path="res://scripts/resources/map_res.gd" id="1_jtlvq"]
-[ext_resource type="Resource" uid="uid://brnuhhyh64c38" path="res://test/test_res/tile_type_pasto.tres" id="2_f3wvc"]
-[ext_resource type="Resource" uid="uid://c4j28ib0pqjwd" path="res://test/test_res/tile_type_montaña.tres" id="3_iielr"]
+[ext_resource type="Script" path="res://scripts/resources/tile_res.gd" id="1_co4aq"]
+[ext_resource type="Script" path="res://scripts/resources/map_res.gd" id="1_jtlvq"]
+[ext_resource type="Resource" path="res://test/test_res/tile_type_pasto.tres" id="2_f3wvc"]
+[ext_resource type="Resource" path="res://test/test_res/tile_type_montaña.tres" id="3_iielr"]
 
 [sub_resource type="Resource" id="Resource_co4aq"]
 script = ExtResource("1_co4aq")

--- a/godot/test/unit/test_habilities.gd
+++ b/godot/test/unit/test_habilities.gd
@@ -56,7 +56,7 @@ func test_attack_2() -> void:
 	var old_hps := enemy_units.map(func (x: UnitGame) -> int: return x.hp)
 	
 	# de paso comprobamos rangos
-	var ranges := GameManager.get_map().get_units_range(ally.get_current_position(), hab_arc.radius, hab_arc.objective)
+	var ranges := GameManager.get_turn_manager().get_map().get_units_range(ally.get_current_position(), hab_arc.radius, hab_arc.objective)
 	assert_eq(ranges.size(), 3)
 	
 	# usar TurnManager para variar
@@ -98,7 +98,7 @@ func test_alter_state() -> void:
 	var old_hps := enemy_units.map(func (x: UnitGame) -> int: return x.hp)
 	
 	# de paso comprobamos rangos
-	var ranges := GameManager.get_map().get_units_range(ally.get_current_position(), hab_fire.radius, hab_fire.objective)
+	var ranges := GameManager.get_turn_manager().get_map().get_units_range(ally.get_current_position(), hab_fire.radius, hab_fire.objective)
 	assert_eq(ranges.size(), 3)
 	
 	# usar TurnManager para variar
@@ -225,8 +225,15 @@ func before_each():
 	var tm : TurnManager = autofree(TurnManager.new())
 	tm.turn_order = [user_ally_game, user_enemy_game]
 	GameManager.register_turn_manager(tm)
-	GameManager.set_map(map_game)
-	GameManager._app_state = GameManager.APP_STATE.IN_GAME
+	GameManager.game_config = GameConfig.new(
+		user_ally,
+		user_enemy,
+		map_game._mapRes,
+		null,
+		null
+	)
+	tm.set_map(map_game)
+	tm.set_app_state(GameManager.APP_STATE.IN_GAME)
 	
 	unit = UnitGame.new(card_melee, user_ally_game)
 	map_game.place_unit(unit, Vector2i(0,0))

--- a/godot/test/unit/test_tick_turn.gd
+++ b/godot/test/unit/test_tick_turn.gd
@@ -36,12 +36,13 @@ func _setup_game_environment() -> Dictionary:
 	var gr := GameResources.load_from("res://test/test_res/all_test_resources.tres")
 	var test_map_game : TestMapGame = autofree(TestMapGame.new())
 	var map := test_map_game.create_test_map()
-	GameManager._gameMap = map
-	GameManager._user_a = gr.users[0]
-	GameManager._user_b = gr.users[1]
-	GameManager._army_a = gr.users[0].obtener_ejercito_activo()
-	GameManager._army_b = gr.users[1].obtener_ejercito_activo()
-	GameManager._app_state = GameManager.APP_STATE.IN_GAME
+	GameManager.game_config = GameConfig.new(
+		gr.users[0],
+		gr.users[1],
+		map._mapRes,
+		gr.users[0].obtener_ejercito_activo(),
+		gr.users[1].obtener_ejercito_activo()
+	)
 	var user_a_game := UserGame.new(gr.users[0])
 	var user_b_game := UserGame.new(gr.users[1])
 	
@@ -50,7 +51,9 @@ func _setup_game_environment() -> Dictionary:
 	var instance := preload("res://scenes/ingame/game_scene.tscn").instantiate() as TurnManager
 	instance.turn_order = [user_a_game, user_b_game]
 	instance.turn_number = 0
+	instance.set_map(map)
 	add_child_autoqfree(instance)
+	instance.set_app_state(GameManager.APP_STATE.IN_GAME)
 	
 	return {
 		"tm": instance,

--- a/godot/test/unit/test_unit.gd
+++ b/godot/test/unit/test_unit.gd
@@ -7,7 +7,10 @@ var map : MapGame
 func before_all():
 	self._gr = GameResources.load_from("res://test/test_res/all_test_resources.tres")
 	self.map = MapGame.new(TestHabilities.gen_test_map())
-	GameManager.set_map(self.map)
+	var tm := TurnManager.new()
+	GameManager.register_turn_manager(tm)
+	GameManager.game_config = GameConfig.new(null, null, self.map._mapRes, null, null)
+	tm.set_map(self.map)
 	
 func test_getters() -> void:
 	var atacker := UnitGame.new(_gr.cards[0], null) #mele


### PR DESCRIPTION
This pull request introduces a significant refactor to how game state and configuration are managed, centralizing key data in a new `GameConfig` resource and shifting map and state access to the `TurnManager`. This change improves code maintainability, testability, and clarity by reducing reliance on global variables and making dependencies explicit. The update touches most of the core gameplay scripts, as well as related tests and configuration files.

Key changes include:

### Game State & Configuration Refactor

* Introduced a new `GameConfig` resource (`game_config.gd`) to encapsulate users, armies, and map configuration, replacing the previous use of multiple global variables in `GameManager`. (`[godot/scripts/game/game_config.gdR1-R15](diffhunk://#diff-757963f8721964c847834fd29641e442fbf264781fa96384eb7dff4578dab165R1-R15)`)
* Updated `GameManager` to use the new `game_config` resource for all game setup and configuration, removing old global variables like `_user_a`, `_army_a`, and `_gameMap`. (`[godot/scripts/game/game_manager.gdL3-R54](diffhunk://#diff-c43a123b8afcf019ea5cad852b92d43735b00dd7768ab1436e6264febf9d947eL3-R54)`)
* Refactored methods throughout the codebase to retrieve game state (users, armies, map, app state) from `TurnManager` and `GameConfig` instead of directly from `GameManager`. (`[[1]](diffhunk://#diff-ab25f3f0a25233fddf63f2feac701c409ac7d16375248afa0dd312e64a840647R45-R74)`, `[[2]](diffhunk://#diff-ab25f3f0a25233fddf63f2feac701c409ac7d16375248afa0dd312e64a840647L75-R121)`, `[[3]](diffhunk://#diff-ab25f3f0a25233fddf63f2feac701c409ac7d16375248afa0dd312e64a840647L100-R138)`, `[[4]](diffhunk://#diff-ab25f3f0a25233fddf63f2feac701c409ac7d16375248afa0dd312e64a840647L119-R157)`, `[[5]](diffhunk://#diff-09f1db01f440efd220e8a09bf2e2e83363fec8012a7e8cce278e3cceccae6b73R95-R116)`, `[[6]](diffhunk://#diff-09f1db01f440efd220e8a09bf2e2e83363fec8012a7e8cce278e3cceccae6b73L244-R253)`)

### Map and Turn Management

* The map is now managed through `TurnManager` (`map_game`), with explicit `get_map` and `set_map` methods, and all map-dependent logic updated to use this approach. (`[[1]](diffhunk://#diff-ab25f3f0a25233fddf63f2feac701c409ac7d16375248afa0dd312e64a840647R45-R74)`, `[[2]](diffhunk://#diff-ab25f3f0a25233fddf63f2feac701c409ac7d16375248afa0dd312e64a840647L75-R121)`, `[[3]](diffhunk://#diff-a3d111ad3a74818ddb08de77a8f514fe37d7e7d5343047ff5e4dbf3c9ce06805L31-R39)`, `[[4]](diffhunk://#diff-3cc62c8193e1b6796a176f4ceb4670e06eafd6157430de0e792b73e210c4df69L27-R31)`)
* All references to the game state (e.g., app state, users, armies) in gameplay and UI scripts are now accessed via `TurnManager` or `GameConfig`, improving encapsulation and modularity. (`[[1]](diffhunk://#diff-ab25f3f0a25233fddf63f2feac701c409ac7d16375248afa0dd312e64a840647R45-R74)`, `[[2]](diffhunk://#diff-ab25f3f0a25233fddf63f2feac701c409ac7d16375248afa0dd312e64a840647L160-R198)`)

### Test and Scene Updates

* Updated test scripts and scene files to use the new `GameConfig` and `TurnManager` structure, ensuring tests remain valid and reflect the new architecture. (`[[1]](diffhunk://#diff-9488d403edfca51f5a14ed26f2243d789d898fd07cdd7c5f87eadd1928f1ec76L9-R12)`, `[[2]](diffhunk://#diff-9488d403edfca51f5a14ed26f2243d789d898fd07cdd7c5f87eadd1928f1ec76L29-R38)`, `[[3]](diffhunk://#diff-9488d403edfca51f5a14ed26f2243d789d898fd07cdd7c5f87eadd1928f1ec76R48)`)
* Minor scene and project configuration tweaks to support new initialization patterns and maintain compatibility. (`[[1]](diffhunk://#diff-af383a6a56ff562f084220190108e0d1841725dbb273aad4c87d7fedebf722b3R8)`, `[[2]](diffhunk://#diff-eb4b3df461ebb5b5f74746040e42220e5f793398dfc40c32d0e0ab6c029ec991R15)`, `[[3]](diffhunk://#diff-eb4b3df461ebb5b5f74746040e42220e5f793398dfc40c32d0e0ab6c029ec991R31-R32)`)

### Miscellaneous Improvements

* Added missing image and portrait assignments in test data for better test coverage. (`[[1]](diffhunk://#diff-9488d403edfca51f5a14ed26f2243d789d898fd07cdd7c5f87eadd1928f1ec76R66-R67)`, `[[2]](diffhunk://#diff-9488d403edfca51f5a14ed26f2243d789d898fd07cdd7c5f87eadd1928f1ec76R77-R78)`, `[[3]](diffhunk://#diff-9488d403edfca51f5a14ed26f2243d789d898fd07cdd7c5f87eadd1928f1ec76R452-R453)`)
* Various minor bug fixes and code cleanups to support the refactor and improve error handling, especially around null checks for map and turn manager instances. (`[[1]](diffhunk://#diff-3cc62c8193e1b6796a176f4ceb4670e06eafd6157430de0e792b73e210c4df69L52-R60)`, `[[2]](diffhunk://#diff-a3d111ad3a74818ddb08de77a8f514fe37d7e7d5343047ff5e4dbf3c9ce06805L147-R151)`)

---

**References:**  
[[1]](diffhunk://#diff-757963f8721964c847834fd29641e442fbf264781fa96384eb7dff4578dab165R1-R15) [[2]](diffhunk://#diff-c43a123b8afcf019ea5cad852b92d43735b00dd7768ab1436e6264febf9d947eL3-R54) [[3]](diffhunk://#diff-ab25f3f0a25233fddf63f2feac701c409ac7d16375248afa0dd312e64a840647R45-R74) [[4]](diffhunk://#diff-ab25f3f0a25233fddf63f2feac701c409ac7d16375248afa0dd312e64a840647L75-R121) [[5]](diffhunk://#diff-ab25f3f0a25233fddf63f2feac701c409ac7d16375248afa0dd312e64a840647L100-R138) [[6]](diffhunk://#diff-ab25f3f0a25233fddf63f2feac701c409ac7d16375248afa0dd312e64a840647L119-R157) [[7]](diffhunk://#diff-09f1db01f440efd220e8a09bf2e2e83363fec8012a7e8cce278e3cceccae6b73R95-R116) [[8]](diffhunk://#diff-09f1db01f440efd220e8a09bf2e2e83363fec8012a7e8cce278e3cceccae6b73L244-R253) [[9]](diffhunk://#diff-a3d111ad3a74818ddb08de77a8f514fe37d7e7d5343047ff5e4dbf3c9ce06805L31-R39) [[10]](diffhunk://#diff-3cc62c8193e1b6796a176f4ceb4670e06eafd6157430de0e792b73e210c4df69L27-R31) [[11]](diffhunk://#diff-9488d403edfca51f5a14ed26f2243d789d898fd07cdd7c5f87eadd1928f1ec76L9-R12) [[12]](diffhunk://#diff-9488d403edfca51f5a14ed26f2243d789d898fd07cdd7c5f87eadd1928f1ec76L29-R38) [[13]](diffhunk://#diff-9488d403edfca51f5a14ed26f2243d789d898fd07cdd7c5f87eadd1928f1ec76R48) [[14]](diffhunk://#diff-9488d403edfca51f5a14ed26f2243d789d898fd07cdd7c5f87eadd1928f1ec76R66-R67) [[15]](diffhunk://#diff-9488d403edfca51f5a14ed26f2243d789d898fd07cdd7c5f87eadd1928f1ec76R77-R78) [[16]](diffhunk://#diff-9488d403edfca51f5a14ed26f2243d789d898fd07cdd7c5f87eadd1928f1ec76R452-R453) [[17]](diffhunk://#diff-af383a6a56ff562f084220190108e0d1841725dbb273aad4c87d7fedebf722b3R8) [[18]](diffhunk://#diff-eb4b3df461ebb5b5f74746040e42220e5f793398dfc40c32d0e0ab6c029ec991R15) [[19]](diffhunk://#diff-eb4b3df461ebb5b5f74746040e42220e5f793398dfc40c32d0e0ab6c029ec991R31-R32) [[20]](diffhunk://#diff-a3d111ad3a74818ddb08de77a8f514fe37d7e7d5343047ff5e4dbf3c9ce06805L147-R151) [[21]](diffhunk://#diff-3cc62c8193e1b6796a176f4ceb4670e06eafd6157430de0e792b73e210c4df69L52-R60)